### PR TITLE
adds support for minijasminenode's showColors option

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = function (options) {
 				isVerbose: options.verbose,
 				includeStackTrace: options.includeStackTrace,
 				defaultTimeoutInterval: options.timeout,
+				showColors: options.showColors,
 				onComplete: function () {cb()}
 			});
 		} catch (err) {

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,13 @@ Default `5000`
 
 Time to wait in milliseconds before a test automatically fails.
 
+##### showColors
+
+Type: `Boolean`
+Default `false`
+
+Print colors to the terminal
+
 
 ## License
 


### PR DESCRIPTION
@sindresorhus - Thanks for taking the time to create and share this gulp plugin! I like to have color output when I run tests in the terminal and thought maybe others might also. So, the changes in my commit: 
-  Add support for the `showColors` option for [minijasminenode's executespecs() function](https://github.com/juliemr/minijasminenode/blob/master/lib/index.js#L70)
-  Add documentation to your repo's README for the `showColors` option in the same format / convention you used for the other options

i.e. 
##### showColors

Type: `Boolean`
Default: `false`

Print colors to the terminal
