### PR TITLE
Jasmine 2.0 Support, and Jasmine Runner to run gulp-jasmine specs

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,18 +3,26 @@ var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
 var requireLike = require('require-like');
-var jasmineRequire = requireLike(require.resolve('minijasminenode'), true);
+var jasmineRequire = requireLike(require.resolve('./'), true);
+var gutilReporter = function(){
+	gutil.log('adding gutil as reporter');
+	return [gutil.log];
+}
 
 module.exports = function (options) {
 	options = options || {};
 
-	var miniJasmineLib = jasmineRequire('minijasminenode');
+	var jasmineBootStrap = jasmineRequire('./jasmine-npm-bootstrap')(false);
 	var color = process.argv.indexOf('--no-color') === -1;
 	var reporter = options.reporter;
 
-	if (reporter) {
-		(Array.isArray(reporter) ? reporter : [reporter]).forEach(miniJasmineLib.addReporter);
-	}
+	var reporters = undefined;
+	if(Array.isArray(reporter))
+		reporters = reporter;
+	else
+		reporters = gutilReporter();
+
+	jasmineBootStrap.addReporters(reporters);
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -28,27 +36,16 @@ module.exports = function (options) {
 		}
 
 		delete require.cache[require.resolve(path.resolve(file.path))];
-		miniJasmineLib.addSpecs(file.path);
+		jasmineBootStrap.addSpecs(file.path);
 
 		this.push(file);
 		cb();
 	}, function (cb) {
 		try {
-			miniJasmineLib.executeSpecs({
-				isVerbose: options.verbose,
-				includeStackTrace: options.includeStackTrace,
-				defaultTimeoutInterval: options.timeout,
-				showColors: color,
-				onComplete: function (arg) {
-					var failedCount = arg.env.currentRunner().results().failedCount;
-
-					if (failedCount > 0) {
-						this.emit('error', new gutil.PluginError('gulp-jasmine', failedCount + ' failure'));
-					}
-
-					cb();
-				}.bind(this)
-			});
+			gutil.log('gulp-jasmine: trying to run jasmine!');
+			jasmineBootStrap.run();
+			cb();
+			gutil.log('gulp-jasmine: end run jasmine!');
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-jasmine', err));
 			cb();

--- a/jasmine-npm-bootstrap.js
+++ b/jasmine-npm-bootstrap.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+var jasmineRequire = require('jasmine-core');
+var jasmine = jasmineRequire.boot(jasmineRequire);
+var program = require("commander");
+var fs = require('fs'),
+  path = require('path'),
+  util = require('util');
+
+var Command = require('./node_modules/jasmine/lib/command');
+var command = new Command(path.resolve(), process.argv);
+
+exports = module.exports = JasmineNpmBootstrap;
+
+//modified jasmine-npm runner
+function JasmineNpmBootstrap(doBootWConfig) {
+  if(doBootWConfig === undefined){//default to true
+    doBootWConfig = true;
+  }
+  this.doBootWConfig = doBootWConfig;
+  self = this;
+  var jasmineRequire = require('jasmine-core');
+  var jasmine = jasmineRequire.boot(jasmineRequire);
+  var jasmineEnv = jasmine.getEnv()
+  var argv = process.argv
+  var specFiles = []
+  var done = function(passed) {
+    if (passed) {
+      // process.exit(0);
+    } else {
+      // process.exit(1);
+    }
+  };
+
+  program
+    .option('--no-color', 'turns off color in output')
+    .parse(argv);
+
+  this.addSpecs = function(path){
+    if(path){
+      specFiles.push(path);
+    }
+  };
+
+  this.addReporters = function(reporters){
+    reporters.forEach(function(r){
+        var consoleReporter = new jasmine.ConsoleReporter({
+          print: r,//defaulted to util.print in jasmine.js npm binary
+          onComplete: done,
+          showColors: program.color,
+          timer: new jasmine.Timer()
+        });
+        jasmineEnv.addReporter(consoleReporter);
+    });
+    util.log("-------Jasmine Reporter Added-------")
+  };
+
+  this.run = function() {
+    self.loadConfigOrSpecFiles()
+    util.log("-------Jasmine Start Execution-------")
+    jasmineEnv.execute();
+    util.log("-------Jasmine Executed-------")
+  };
+
+  this.loadConfigOrSpecFiles = function() {
+    jasmineEnv.defaultTimeoutInterval = 5000;
+    if(command.execJasmine && self.doBootWConfig) {
+      util.log("-------Loading Configs via Jasmine Config-------")
+      var Config = require('./node_modules/jasmine/lib/config.js');
+      var config = new Config(path.resolve());
+
+      config.specFiles().forEach(function(file) {
+        require(file);
+      });
+    }
+    else{
+      util.log("-------Loading Specs From Stream Files Names-------")
+      specFiles.forEach(function(filename){
+        try {
+          util.log("-------Attempting to load file: " + filename + "-------")
+          require(path.resolve(process.cwd(), filename));
+        } catch (e) {
+          // Generate a synthetic suite with a failure spec, so that the failure is
+          // reported with other results.
+          jasmineEnv.describe('Exception loading: ' + filename, function() {
+            jasmineEnv.it('Error', function() { throw e; });
+          });
+        }
+      });
+    }
+  };
+  return this;
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "jasmine"
   },
   "files": [
     "index.js"
@@ -36,9 +36,9 @@
     "gulp-util": "^2.2.0",
     "minijasminenode": "^0.4.0",
     "require-like": "^0.1.2",
-    "through2": "~0.4.0"
-  },
-  "devDependencies": {
-    "mocha": "*"
+    "through2": "~0.4.0",
+    "jasmine-core": "https://github.com/pivotal/jasmine/archive/jasmine-node2.tar.gz",
+    "jasmine": "https://github.com/pivotal/jasmine-npm/archive/master.tar.gz",
+    "commander": "~2.1.0"
   }
 }

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -1,7 +1,7 @@
 'use strict';
 var assert = require('assert');
 var gutil = require('gulp-util');
-var jasmine = require('./index');
+var jasmine = require('../index');
 var through2 = require('through2');
 var out = process.stdout.write.bind(process.stdout);
 
@@ -9,9 +9,9 @@ it('should run unit test and pass', function (cb) {
 	var stream = jasmine({verbose: true});
 
 	process.stdout.write = function (str) {
-		out(str);
+		// out(str);
 
-		if (/should pass/.test(str)) {
+		if (/1 spec, 0 failures/.test(str)) {
 			assert(true);
 			process.stdout.write = out;
 			cb();
@@ -21,8 +21,8 @@ it('should run unit test and pass', function (cb) {
 	stream.write(new gutil.File({
 		path: 'fixture.js',
 		contents: new Buffer('')
-	}));
 
+	}));
 	stream.end();
 });
 
@@ -33,7 +33,8 @@ it('should run the test only once even if called in succession', function (done)
 		cb();
 	}, function (cb) {
 		process.stdout.write = out;
-		assert.equal(output.match(/should pass/g).length, 1);
+		// out(output);
+		assert.equal(output.match(/1 spec, 0 failures/g).length, 1);
 		done();
 		cb();
 	});
@@ -51,3 +52,5 @@ it('should run the test only once even if called in succession', function (done)
 
 	stream.end();
 });
+
+gutil.log("end: test suite !");

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,9 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ]
+}


### PR DESCRIPTION
Original Thoughts:
Not sure if this is worth the hassel, but I thought I would try out jasmine-npm and then see if I can use it to replace minijasminenode.

So this is just a start by getting rid of mocha

making this gulp plugin project pure jasmine, to test out jasmine-npm

Post mortem:
I was able to port the interface from minijasminenode to the included file jasmine-npm-bootstrap. I was able to successfully get things running enough to get the specs passing. I know there is more tweaking needed and I am totally open to feedback.

Heck I can even re-target the pull to a jasmine2 branch on your repo if you want.
