### PR TITLE
Modification of deleting cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,17 @@ module.exports = function (options) {
 			return cb();
 		}
 
+		/**
+		 * Get the cacheobkect of the specs.js file,
+		 * get it's children and delete the childrens cache
+		 */
+		var files = require.cache[require.resolve(path.resolve(file.path))];
+		if (typeof files !== 'undefined') {
+			for (var i in files.children) {
+				delete require.cache[files.children[i].id];
+			}
+		}
+
 		delete require.cache[require.resolve(path.resolve(file.path))];
 		miniJasmineLib.addSpecs(file.path);
 


### PR DESCRIPTION
Added delete of the full cache of the specs. The children of the specs.js cache are now also deleted.

Now the test run correctly after every save of the files. So yo're able to use it in a watch().
