### PR TITLE
Add silent option to forward to minijasminenode

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = function (options) {
 	}, function (cb) {
 		try {
 			miniJasmineLib.executeSpecs({
+				silent: options.silent,
 				isVerbose: options.verbose,
 				includeStackTrace: options.includeStackTrace,
 				defaultTimeoutInterval: options.timeout,

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,13 @@ Type: `object`, `array` of `objects`
 
 Reporters to use.
 
+##### silent
+
+Type: `boolean`
+Default: `false`
+
+Display nothing during the tests run.
+
 ##### verbose
 
 Type: `boolean`  


### PR DESCRIPTION
[minijasminenode](https://github.com/juliemr/minijasminenode) already has support for disabling the terminal reporter: see it [here](https://github.com/juliemr/minijasminenode/pull/17).

I created a issue and proposed a [pull request](https://github.com/juliemr/minijasminenode/pull/25) for adding the same support for minijasminenode2. This adds the interface for forwarding the option to minijasminenode.

Consider it when support will be added in minijasminenode2.
