### PR TITLE
when deleting cached file, do it recursively

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var through = require('through2');
 var Jasmine = require('jasmine');
 
 function deleteRequireCache( id ) {
+	// recursively delete source code to be tested, 
+	// but skip mature code loaded from node_modules
+	if(id.indexOf('node_modules') >= 0) return;
 	var files = require.cache[ id ];
 	if (typeof files !== 'undefined') {
 		for (var i in files.children) {


### PR DESCRIPTION
deleting spec and its directly children is not enough. if a source code file required by its children, should also be reloaded. 

so need delete recursively, but skip all files from node_modules, as they are regarded mature and not being modified.