### PR TITLE
Allowing parallel streams to not prevent test from running from other streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ function deleteRequireCache(id) {
 }
 
 module.exports = function (options) {
-	var jasmineAlreadyRunning = true;
 	options = options || {};
 
 	// Keep a reference to the jasmine instance that is created until it is executed to allow multiple pipes to jasmine-gulp to
@@ -35,7 +34,6 @@ module.exports = function (options) {
 	var jasmine = jasmineInstance;
 	if (!jasmine) {
 		jasmine = jasmineInstance = new Jasmine();
-		jasmineAlreadyRunning = false;
 
 		if (options.timeout) {
 			jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = options.timeout;
@@ -78,7 +76,7 @@ module.exports = function (options) {
 		cb(null, file);
 	}, function (cb) {
 		try {
-			if (!jasmineAlreadyRunning) {
+			if (jasmineInstance) {
 				jasmineInstance = null; // release the global jasmine instance.
 				jasmine.addReporter(new SilentReporter(cb));
 				jasmine.execute();

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var through = require('through2');
 var Jasmine = require('jasmine');
 var Reporter = require('jasmine-terminal-reporter');
 var SilentReporter = require('./silent-reporter');
+var jasmineInstance;
 
 function deleteRequireCache(id) {
 	if (id.indexOf('node_modules') !== -1) {
@@ -23,27 +24,37 @@ function deleteRequireCache(id) {
 }
 
 module.exports = function (options) {
+	var jasmineAlreadyRunning = true;
 	options = options || {};
 
-	var jasmine = new Jasmine();
+	// Keep a reference to the jasmine instance that is created until it is executed to allow multiple pipes to jasmine-gulp to
+	// aggregate their files.
+	// Without this overlapping calls to jasmine-gulp from streams running in parallel will only run the tests from the last stream
+	// to call jasmine-gulp.
+	// TODO: figure out a way to combine their reporters.
+	var jasmine = jasmineInstance;
+	if (!jasmine) {
+		jasmine = jasmineInstance = new Jasmine();
+		jasmineAlreadyRunning = false;
 
-	if (options.timeout) {
-		jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = options.timeout;
-	}
+		if (options.timeout) {
+			jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = options.timeout;
+		}
 
-	var color = process.argv.indexOf('--no-color') === -1;
-	var reporter = options.reporter;
+		var color = process.argv.indexOf('--no-color') === -1;
+		var reporter = options.reporter;
 
-	if (reporter) {
-		(Array.isArray(reporter) ? reporter : [reporter]).forEach(function (el) {
-			jasmine.addReporter(el);
-		});
-	} else {
-		jasmine.addReporter(new Reporter({
-			isVerbose: options.verbose,
-			showColors: color,
-			includeStackTrace: options.includeStackTrace
-		}));
+		if (reporter) {
+			(Array.isArray(reporter) ? reporter : [reporter]).forEach(function (el) {
+				jasmine.addReporter(el);
+			});
+		} else {
+			jasmine.addReporter(new Reporter({
+				isVerbose: options.verbose,
+				showColors: color,
+				includeStackTrace: options.includeStackTrace
+			}));
+		}
 	}
 
 	return through.obj(function (file, enc, cb) {
@@ -62,15 +73,20 @@ module.exports = function (options) {
 		var resolvedPath = path.resolve(file.path);
 		var modId = require.resolve(resolvedPath);
 		deleteRequireCache(modId);
-
 		jasmine.addSpecFile(resolvedPath);
 
 		cb(null, file);
 	}, function (cb) {
 		try {
-			jasmine.addReporter(new SilentReporter(cb));
-			jasmine.execute();
+			if (!jasmineAlreadyRunning) {
+				jasmineInstance = null; // release the global jasmine instance.
+				jasmine.addReporter(new SilentReporter(cb));
+				jasmine.execute();
+			} else {
+				cb();
+			}
 		} catch (err) {
+			jasmineInstance = null; // release the global jasmine instance.
 			cb(new gutil.PluginError('gulp-jasmine', err));
 		}
 	});

--- a/otherFixture.js
+++ b/otherFixture.js
@@ -1,0 +1,6 @@
+describe('other fixture', function () {
+	it('should pass another test', function (done) {
+		expect(1).toBe(1);
+		done();
+	});
+});

--- a/test.js
+++ b/test.js
@@ -57,3 +57,50 @@ it('should run the test only once even if called in succession', function (done)
 
 	stream.end();
 });
+
+it('should run all tests when new tests are added while running tests.', function (done) {
+	var numTasks = 0;
+	var output = '';
+	var oldWrite = process.stdout.write;
+	process.stdout.write = function (str) {
+		output += str;
+	};
+	var startStream = function() {
+		numTasks++;
+		var stream = jasmine({
+			timeout: 9000,
+			verbose: true
+		});
+		var reader = through2.obj(function (file, enc, cb) {
+			cb();
+		}, function (cb) {
+			process.stdout.write = out;
+			assert.equal(output.match(/should pass another test: passed/g).length, 1);
+			if (--numTasks <= 0) {
+				done();
+			}
+			cb();
+		});
+
+		stream.pipe(reader);
+
+		return stream;
+	};
+
+	var otherFixtureStream = startStream();
+	var fixtureStream = startStream();
+
+
+	fixtureStream.write(new gutil.File({
+		path: 'fixture.js',
+		contents: new Buffer('')
+	}));
+
+	otherFixtureStream.write(new gutil.File({
+		path: 'otherFixture.js',
+		contents: new Buffer('')
+	}));
+
+	fixtureStream.end();
+	otherFixtureStream.end();
+});


### PR DESCRIPTION
suggested fix for: #42 

Not entirely happy with the fact that the reporters are not joined from both streams, but adding them both means duplicate reporting if you set both streams up the same way (or if the streams need to be used independently).

Let me know if you have any suggestions for updates.