### PR TITLE
Fixing TypeError exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var Reporter = require('jasmine-terminal-reporter');
 var SilentReporter = require('./silent-reporter');
 
 function deleteRequireCache(id) {
-	if (id.indexOf('node_modules') !== -1) {
+	if (id===undefined||id.indexOf('node_modules') !== -1) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var Reporter = require('jasmine-terminal-reporter');
 var SilentReporter = require('./silent-reporter');
 
 function deleteRequireCache(id) {
-	if (id===undefined||id.indexOf('node_modules') !== -1) {
+	if (!id||id.indexOf('node_modules') !== -1) {
 		return;
 	}
 


### PR DESCRIPTION
ended up getting the following error when running the plugin:
C:\dev\Libraries\clarity\node_modules\gulp-jasmine\index.js:10
        if (id.indexOf('node_modules') !== -1) {
              ^
TypeError: Cannot call method 'indexOf' of undefined

Just adding in a check to see if id is undefined.