### PR TITLE
Add options.jasmine

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function deleteRequireCache(id) {
 module.exports = function (options) {
 	options = options || {};
 
-	var jasmine = new Jasmine();
+	var jasmine = options.jasmine || new Jasmine();
 
 	if (options.timeout) {
 		jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = options.timeout;

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,17 @@ Default `5000`
 
 Time to wait in milliseconds before a test automatically fails.
 
+##### jasmine
+
+Type: `object`
+
+Custom instance of the Jasmine class from [jasmine-npm module](https://github.com/jasmine/jasmine-npm). Can be created like
+
+```js
+var Jasmine = require('jasmine');
+var instance = new Jasmine();
+```
+
 
 ## License
 


### PR DESCRIPTION
Hi!

It would be nice if gulp-jasmine would allow users to inject a custom instance of the Jasmine module.

- A specific version of the Jasmine could be used.
- Jasmine could be configured before use. For example the standard spec filter could be replaced with a custom one.

This change is super small but could make gulp-jasmine much more flexible.