### PR TITLE
PoC: Run jasmine in separate process

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,51 +1,18 @@
 'use strict';
 var path = require('path');
-var arrify = require('arrify');
 var gutil = require('gulp-util');
 var through = require('through2');
-var Jasmine = require('jasmine');
-var Reporter = require('jasmine-terminal-reporter');
-var SilentReporter = require('./silent-reporter');
-
-function deleteRequireCache(id) {
-	if (!id || id.indexOf('node_modules') !== -1) {
-		return;
-	}
-
-	var files = require.cache[id];
-
-	if (files !== undefined) {
-		for (var file in files.children) {
-			deleteRequireCache(files.children[file].id);
-		}
-
-		delete require.cache[id];
-	}
-}
 
 module.exports = function (options) {
+	var runner = require('child_process').fork('./runner');
+
 	options = options || {};
+	options.showColors = process.argv.indexOf('--no-color') === -1;
 
-	var jasmine = new Jasmine();
-
-	if (options.timeout) {
-		jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = options.timeout;
-	}
-
-	var color = process.argv.indexOf('--no-color') === -1;
-	var reporter = options.reporter;
-
-	if (reporter) {
-		arrify(reporter).forEach(function (el) {
-			jasmine.addReporter(el);
-		});
-	} else {
-		jasmine.addReporter(new Reporter({
-			isVerbose: options.verbose,
-			showColors: color,
-			includeStackTrace: options.includeStackTrace
-		}));
-	}
+	runner.send({
+		type: 'instantiate',
+		options: options
+	});
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -54,25 +21,25 @@ module.exports = function (options) {
 		}
 
 		if (file.isStream()) {
+			runner.kill();
 			cb(new gutil.PluginError('gulp-jasmine', 'Streaming not supported'));
 			return;
 		}
 
-		// get the cache object of the specs.js file,
-		// delete it and its children recursively from cache
-		var resolvedPath = path.resolve(file.path);
-		var modId = require.resolve(resolvedPath);
-		deleteRequireCache(modId);
-
-		jasmine.addSpecFile(resolvedPath);
+		runner.send({
+			type: 'addSpec',
+			path: path.resolve(file.path)
+		});
 
 		cb(null, file);
 	}, function (cb) {
-		try {
-			jasmine.addReporter(new SilentReporter(cb));
-			jasmine.execute();
-		} catch (err) {
-			cb(new gutil.PluginError('gulp-jasmine', err));
-		}
+		runner.on('message', function (err) {
+			cb(err);
+			runner.kill();
+		});
+
+		runner.send({
+			type: 'run'
+		});
 	});
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "files": [
     "index.js",
+    "runner.js",
     "silent-reporter.js"
   ],
   "keywords": [

--- a/runner.js
+++ b/runner.js
@@ -1,0 +1,70 @@
+var arrify = require('arrify');
+var gutil = require('gulp-util');
+var Jasmine = require('jasmine');
+var Reporter = require('jasmine-terminal-reporter');
+var SilentReporter = require('./silent-reporter');
+
+var jasmine;
+var uncaughtError = null;
+
+function instantiate (options) {
+	jasmine = new Jasmine();
+
+	if (options.timeout) {
+		jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = options.timeout;
+	}
+
+	if (options.reporter) {
+		arrify(options.reporter).forEach(function (reporter) {
+			jasmine.addReporter(reporter);
+		});
+	} else {
+		jasmine.addReporter(new Reporter({
+			isVerbose: options.verbose,
+			showColors: options.showColors,
+			includeStackTrace: options.includeStackTrace
+		}));
+	}
+}
+
+function addSpec (path) {
+	jasmine.addSpecFile(path);
+}
+
+function run () {
+	try {
+		jasmine.addReporter(new SilentReporter(function (err) {
+			if (uncaughtError) {
+				err = new gutil.PluginError('gulp-jasmine', uncaughtError);
+			}
+			process.send(err || null);
+		}));
+		jasmine.execute();
+	} catch (err) {
+		process.send(new gutil.PluginError('gulp-jasmine', err));
+	}
+}
+
+process.on('uncaughtException', function (err) {
+	uncaughtError = err;
+});
+
+process.on('message', function(message) {
+	if (!message || !message.type) {
+		throw new Error('message.type must be defined');
+	}
+
+	switch (message.type) {
+		case 'instantiate':
+			instantiate(message.options);
+			break;
+		case 'addSpec':
+			addSpec(message.path);
+			break;
+		case 'run':
+			run();
+			break;
+		default:
+			throw new Error('Message type ' + message.type + ' not supported');
+	}
+});

--- a/silent-reporter.js
+++ b/silent-reporter.js
@@ -1,5 +1,4 @@
 'use strict';
-var gutil = require('gulp-util');
 
 module.exports = function (cb) {
 	var failureCount = 0;
@@ -31,9 +30,7 @@ module.exports = function (cb) {
 		process.send({ event: 'jasmineDone' });
 
 		if (failureCount > 0) {
-			cb(new gutil.PluginError('gulp-jasmine', 'Tests failed', {
-				showStack: false
-			}));
+			cb('Tests failed');
 			return;
 		}
 

--- a/silent-reporter.js
+++ b/silent-reporter.js
@@ -4,13 +4,32 @@ var gutil = require('gulp-util');
 module.exports = function (cb) {
 	var failureCount = 0;
 
+	this.jasmineStarted = function (info) {
+		process.send({ event: 'jasmineStarted', data: info });
+	};
+
+	this.suiteStarted = function (suiteInfo) {
+		process.send({ event: 'suiteStarted', data: suiteInfo });
+	};
+
+	this.specStarted = function (specInfo) {
+		process.send({ event: 'specStarted', data: specInfo });
+	};
+
 	this.specDone = function (result) {
+		process.send({ event: 'specDone', data: result });
 		if (result.status === 'failed') {
 			failureCount++;
 		}
 	};
 
+	this.suiteDone = function (result) {
+		process.send({ event: 'suiteDone', data: result });
+	};
+
 	this.jasmineDone = function () {
+		process.send({ event: 'jasmineDone' });
+
 		if (failureCount > 0) {
 			cb(new gutil.PluginError('gulp-jasmine', 'Tests failed', {
 				showStack: false


### PR DESCRIPTION
This is a proof of concept for a refactoring of gulp-jasmine to run jasmine inside a separate process. This solves 3 problems:

1) **having to clear the module cache before running**: since the tests are run inside a new process every time, the dependencies are always reloaded.

2) **having uncaught asynchronous exceptions crash the gulp process**: since we run in a separate process, we can add an uncaughtException handler and report the exception back to the main process as a gulp error.

3) **having the gulp process hang when external event handlers are not closed correctly by a spec**: since the tests are run in a separate process, unclosed web servers or database connections won't prevent gulp from finishing.

I'm aware that the mocha tests are crashing. I believe this is due to the replacing of the process.stdout.write.

This code is not ready for merging. I just want to have some feedback. Let me know what you think.