### PR TITLE
Jasmine's loadConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,10 @@ module.exports = function (options) {
 		jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = options.timeout;
 	}
 
+	if (options.config) {
+		jasmine.loadConfig(options.config)
+	}
+
 	var color = process.argv.indexOf('--no-color') === -1;
 	var reporter = options.reporter;
 

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,11 @@ Default `5000`
 
 Time to wait in milliseconds before a test automatically fails.
 
+##### config
+
+Type: `object`  
+
+If passed Jasmine's loadConfig will be called passing the provided object.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ Time to wait in milliseconds before a test automatically fails.
 
 Type: `object`  
 
-If passed Jasmine's loadConfig will be called passing the provided object.
+If passed Jasmine's [loadConfig](http://jasmine.github.io/2.3/node.html#section-Load_configuration_from_a_file_or_from_an_object.) will be called passing the provided object.
 
 ## License
 


### PR DESCRIPTION
Jasmine has a [loadConfig](http://jasmine.github.io/2.3/node.html#section-Using_the_library) method which takes an object that is able to define helpers that will be loaded before the specs themselves.  This is useful for adding matchers as demonstrated in the jasmine examples (generate with jasmine examples).  This pull request adds option.config which if passed will be passed into Jasmine's loadConfig method.