### PR TITLE
Allow custom matchers to be provided in options

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -29,3 +29,9 @@ xdescribe('the timeout', function () {
 		}, 6000);
 	});
 });
+
+describe('custom matchers', function () {
+	it('should be able to run the custom matcher', function () {
+		expect(1).toBeTheNumberOne();
+	});
+});

--- a/fixture.js
+++ b/fixture.js
@@ -21,7 +21,7 @@ describe('beforeAll', function () {
 });
 
 xdescribe('the timeout', function () {
-	it('should pass', function (done) {
+	it('should only pass after a delay', function (done) {
 		expect(1).toBe(1);
 
 		setTimeout(function () {

--- a/fixture.js
+++ b/fixture.js
@@ -31,7 +31,8 @@ xdescribe('the timeout', function () {
 });
 
 describe('custom matchers', function () {
-	it('should be able to run the custom matcher', function () {
+	it('should be able to assert with custom matchers', function () {
 		expect(1).toBeTheNumberOne();
+		expect(3).not.toBeTheNumberTwo();
 	});
 });

--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ function addMatchers(jasmine, options) {
 
 	if (matchers) {
 		beforeEach(function () {
-			jasmine.addMatchers(matchers);
+			arrify(matchers).forEach(function (el) {
+				jasmine.addMatchers(el);
+			});
 		});
 	}
 }

--- a/index.js
+++ b/index.js
@@ -23,19 +23,7 @@ function deleteRequireCache(id) {
 	}
 }
 
-module.exports = function (options) {
-	options = options || {};
-
-	var jasmine = new Jasmine();
-
-	if (options.timeout) {
-		jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = options.timeout;
-	}
-
-	if (options.config) {
-		jasmine.loadConfig(options.config)
-	}
-
+function addReporter(jasmine, options) {
 	var color = process.argv.indexOf('--no-color') === -1;
 	var reporter = options.reporter;
 
@@ -50,6 +38,33 @@ module.exports = function (options) {
 			includeStackTrace: options.includeStackTrace
 		}));
 	}
+}
+
+function addMatchers(jasmine, options) {
+	var matchers = options.matchers;
+
+	if (matchers) {
+		beforeEach(function () {
+			jasmine.addMatchers(matchers);
+		});
+	}
+}
+
+module.exports = function (options) {
+	options = options || {};
+
+	var jasmine = new Jasmine();
+
+	if (options.timeout) {
+		jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = options.timeout;
+	}
+
+	if (options.config) {
+		jasmine.loadConfig(options.config)
+	}
+
+	addReporter(jasmine, options);
+	addMatchers(jasmine.jasmine, options);
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {

--- a/readme.md
+++ b/readme.md
@@ -34,14 +34,14 @@ gulp.task('default', () => {
 
 ##### verbose
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Display spec names in default reporter.
 
 ##### includeStackTrace
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Include stack traces in failures in default reporter.
@@ -67,9 +67,31 @@ gulp.task('default', () => {
 
 [Creating your own reporter.](http://jasmine.github.io/2.1/custom_reporter.html)
 
+##### matchers
+
+Type: `object`
+
+Matchers to use.
+
+```js
+const gulp = require('gulp');
+const jasmine = require('gulp-jasmine');
+const jasmineMatchers = require('jasmine-expect');
+
+gulp.task('default', () => {
+  return gulp.src('spec/test.js')
+    .pipe(jasmine({
+      matchers: jasmineMatchers
+    }));
+});
+```
+
+[Creating your own matchers.](http://jasmine.github.io/2.1/custom_matcher.html)
+
+
 ##### timeout
 
-Type: `number`  
+Type: `number`
 Default `5000`
 
 Time to wait in milliseconds before a test automatically fails.

--- a/readme.md
+++ b/readme.md
@@ -69,19 +69,19 @@ gulp.task('default', () => {
 
 ##### matchers
 
-Type: `object`
+Type: `object`, `array` of `objects`
 
 Matchers to use.
 
 ```js
 const gulp = require('gulp');
 const jasmine = require('gulp-jasmine');
-const jasmineMatchers = require('jasmine-expect');
+const myJasmineMatchers = require('./my-jasmine-matchers');
 
 gulp.task('default', () => {
   return gulp.src('spec/test.js')
     .pipe(jasmine({
-      matchers: jasmineMatchers
+      matchers: myJasmineMatchers
     }));
 });
 ```

--- a/test.js
+++ b/test.js
@@ -5,11 +5,26 @@ var through2 = require('through2');
 var jasmine = require('./');
 var out = process.stdout.write.bind(process.stdout);
 
+var numberOneMatcher = function () {
+	return {
+		compare: function (value) {
+			var isOne = value === 1;
+			return {
+				pass: isOne,
+				message: isOne ? "Expected " + value + " not to be 1" : "Expected " + value + " to be 1"
+			};
+		}
+	}
+};
+
 describe('gulp-jasmine', function () {
 	beforeEach(function () {
 		this.stream = jasmine({
 			timeout: 9000,
-			verbose: true
+			verbose: true,
+			matchers: {
+				toBeTheNumberOne: numberOneMatcher
+			}
 		});
 
 		this.writeFileOnStream = function () {

--- a/test.js
+++ b/test.js
@@ -5,55 +5,68 @@ var through2 = require('through2');
 var jasmine = require('./');
 var out = process.stdout.write.bind(process.stdout);
 
-it('should run unit test and pass', function (cb) {
-	var stream = jasmine({
-		timeout: 9000,
-		verbose: true
+describe('gulp-jasmine', function () {
+	beforeEach(function () {
+		this.stream = jasmine({
+			timeout: 9000,
+			verbose: true
+		});
+
+		this.writeFileOnStream = function () {
+			this.stream.write(new gutil.File({
+				path: 'fixture.js',
+				contents: new Buffer('')
+			}));
+
+			this.stream.end();
+		};
 	});
 
-	process.stdout.write = function (str) {
-		out(str);
+	describe('simple unit test', function () {
+		beforeEach(function () {
+			process.stdout.write = function (str) {
+				this.assertion(str);
+			}.bind(this);
+		});
 
-		if (/should pass/.test(str)) {
-			assert(true);
-			process.stdout.write = out;
-			cb();
-		}
-	};
+		it('should run and pass', function (done) {
+			this.assertion = function (str) {
+				if (/should pass/.test(str)) {
+					process.stdout.write = out;
+					assert(true);
+					done();
+				}
+			};
 
-	stream.write(new gutil.File({
-		path: 'fixture.js',
-		contents: new Buffer('')
-	}));
-
-	stream.end();
-});
-
-it('should run the test only once even if called in succession', function (done) {
-	var stream = jasmine({
-		timeout: 9000,
-		verbose: true
-	});
-	var output = '';
-	var reader = through2.obj(function (file, enc, cb) {
-		cb();
-	}, function (cb) {
-		process.stdout.write = out;
-		assert.equal(output.match(/should pass/g).length, 1);
-		done();
-		cb();
+			this.writeFileOnStream();
+		});
 	});
 
-	process.stdout.write = function (str) {
-		output += str;
-	};
+	describe('if called in succession', function () {
+		beforeEach(function () {
+			var output = '';
+			process.stdout.write = function (str) {
+				output += str;
+			};
 
-	stream.pipe(reader);
+			var reader = through2.obj(function (file, enc, cb) {
+				cb();
+			}, function (cb) {
+				this.assertion(output);
+				cb();
+			}.bind(this));
 
-	stream.write(new gutil.File({
-		path: 'fixture.js',
-		contents: new Buffer('')
-	}));
+			this.stream.pipe(reader);
+		});
 
-	stream.end();
+		it('should run the test only once', function (done) {
+			this.assertion = function (str) {
+				process.stdout.write = out;
+				assert.equal(str.match(/should pass/g).length, 1);
+				done();
+			};
+
+			this.writeFileOnStream();
+		});
+	});
 });

--- a/test.js
+++ b/test.js
@@ -5,14 +5,16 @@ var through2 = require('through2');
 var jasmine = require('./');
 var out = process.stdout.write.bind(process.stdout);
 
-var numberOneMatcher = function () {
-	return {
-		compare: function (value) {
-			var isOne = value === 1;
-			return {
-				pass: isOne,
-				message: isOne ? "Expected " + value + " not to be 1" : "Expected " + value + " to be 1"
-			};
+var numberMatcher = function (number) {
+	return function () {
+		return {
+			compare: function (value) {
+				var isNumber = value === number;
+				return {
+					pass: isNumber,
+					message: isNumber ? "Expected " + value + " not to be " + number : "Expected " + value + " to be " + number
+				};
+			}
 		}
 	}
 };
@@ -22,9 +24,10 @@ describe('gulp-jasmine', function () {
 		this.stream = jasmine({
 			timeout: 9000,
 			verbose: true,
-			matchers: {
-				toBeTheNumberOne: numberOneMatcher
-			}
+			matchers: [
+				{ toBeTheNumberOne: numberMatcher(1) },
+				{ toBeTheNumberTwo: numberMatcher(2) }
+			]
 		});
 
 		this.writeFileOnStream = function () {


### PR DESCRIPTION
This change aims to allow custom matchers to be provided to Jasmine, much in the same way as reporters are set. This removes the necessity for any Jasmine setup script and allows the configuration to be contained in the gulp task. The example below has been added to the documentation.

```js
const gulp = require('gulp');
const jasmine = require('gulp-jasmine');
const myJasmineMatchers = require('./my-jasmine-matchers');

gulp.task('default', () => {
  return gulp.src('spec/test.js')
    .pipe(jasmine({
      matchers: myJasmineMatchers
    }));
});
```

Additionally, this PR modifies the test code structure in the test file, pushing as much setup logic in the pre-assertion functions to keep spec blocks concise and remove duplicated setup code.

It may help to view the files change with whitespace diffing disabled: https://github.com/sindresorhus/gulp-jasmine/pull/63/files?w=1