### PR TITLE
Added 'end' event emit on Jasmine complete.

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,10 @@ module.exports = function (opts) {
 		cb(null, file);
 	}, function (cb) {
 		try {
+			var self = this;
+			jasmine.onComplete(function() {
+				self.emit('end');
+			});
 			if (jasmine.helperFiles) {
 				jasmine.helperFiles.forEach(function (helper) {
 					var resolvedPath = path.resolve(helper);


### PR DESCRIPTION
Otherwise, there is no a way to know when to finish a gulp task.