### PR TITLE
Allow projectBaseDir to be specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ function deleteRequireCache(id) {
 module.exports = function (opts) {
 	opts = opts || {};
 
-	var jasmine = new Jasmine();
+	var jasmine = new Jasmine({
+		projectBaseDir: opts.projectBaseDir
+	});
 
 	if (opts.timeout) {
 		jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = opts.timeout;


### PR DESCRIPTION
Optionally pass on the projectBaseDir parameter to the underlying Jasmine
object.  Together with config.spec_dir, this allows full control over the
absolute/relative file paths of the configuration file, helper files and spec
files.