### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,15 +33,15 @@
     "unit"
   ],
   "dependencies": {
-    "arrify": "^1.0.0",
-    "jasmine": "^2.8.0",
+    "arrify": "^1.0.1",
+    "jasmine": "^3.1.0",
     "jasmine-terminal-reporter": "^1.0.3",
-    "plugin-error": "^0.1.2",
-    "through2": "^2.0.0"
+    "plugin-error": "^1.0.1",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "ava": "*",
-    "gulp": "^3.8.7",
+    "gulp": "^4.0.0",
     "vinyl": "^2.1.0",
     "xo": "*"
   },


### PR DESCRIPTION
Upgrade the following dependencies:
  - Gulp 3 -> Gulp 4
  - Jasmine 2 -> Jasmine 3. This also solves this plugin from being [reported by Snyk](https://snyk.io/vuln/npm:jasmine-core:20180216).
  - `through2`
  - `arrify`
  - `plugin-error`

I went through the code base and nothing had to be changed, it works as is. However upgrading to a major release might be better for safety purpose.